### PR TITLE
add userOptionLinks

### DIFF
--- a/src/components/gw-header.vue
+++ b/src/components/gw-header.vue
@@ -13,7 +13,7 @@
                         @select="company => $emit('selected-company', company)"
                     />
                 </slot>
-                <slot name="app-switcher">
+                <slot name="app-switcher" v-if="showAppSwitcher">
                     <gw-app-switcher />
                 </slot>
             </div>
@@ -21,6 +21,7 @@
                 <gw-user-options
                     :company-data="companyData"
                     :user-data="userData"
+                    :links="userOptionLinks"
                 />
                 <gw-notifications
                     :count="notificationsCount"
@@ -71,9 +72,16 @@ export default {
             type: Boolean,
             default: false
         },
+        showAppSwitcher: {
+            type: Boolean,
+            default: true
+        },
         userData: {
             type: Object,
             required: true
+        },
+        userOptionLinks: {
+            type: [Array, null]
         }
     }
 };

--- a/src/components/gw-user-options.vue
+++ b/src/components/gw-user-options.vue
@@ -20,17 +20,8 @@
         </template>
         <template slot="body">
             <span class="dropdown-title">My Profile</span>
-            <router-link :to="{ name: 'settingsUsersProfile' }" class="dropdown-item">
-                <span>Users Settings</span>
-            </router-link>
-            <router-link :to="{ name: 'settingsCompaniesProfile' }" class="dropdown-item">
-                <span>{{ companyData.name }} Settings</span>
-            </router-link>
-            <router-link :to="{ name: 'settingsAppsCustomFieldsList' }" class="dropdown-item">
-                <span>App Settings</span>
-            </router-link>
-            <router-link :to="{ name: 'settingsManagerList' }" class="dropdown-item">
-                <span>Companies Manager</span>
+            <router-link  v-for="item in dropdownOptionsVisible" :key="item.name" :to="{ name: item.name }" class="dropdown-item">
+                <span> {{ item.label }}</span>
             </router-link>
             <a href="#" class="dropdown-item logout-button" @click.prevent="logout()">
                 <span>Logout</span>
@@ -51,6 +42,17 @@ export default {
         userData: {
             type: Object,
             required: true
+        },
+        links: {
+            type: [Array, null],
+            default() {
+                return [
+                    "settingsUsersProfile",
+                    "settingsCompaniesProfile",
+                    "settingsAppsCustomFieldsList",
+                    "settingsManagerList"
+                ]
+            }
         }
     },
     data() {
@@ -58,8 +60,34 @@ export default {
             userDropdownCoordenates: {
                 x: -45,
                 y: 0
-            }
+            },
+            
         };
+    },
+    computed: {
+        dropdownOptionsAvailable() { 
+            return [
+                {
+                    name: "settingsUsersProfile",
+                    label: "Users Settings"
+                }, 
+                {
+                    name: "settingsCompaniesProfile",
+                    label: `${this.companyData.name} Settings`
+                },
+                {
+                    name: "settingsAppsCustomFieldsList",
+                    label: "App settings"
+                },
+                {
+                   name: "settingsManagerList",
+                   label: "Companies Manager"
+                }
+            ]
+        },
+        dropdownOptionsVisible() {
+            return this.dropdownOptionsAvailable.filter(item => this.links.includes(item.name))
+        }
     },
     created() {
         this.handleUserDropdownCoordenates();


### PR DESCRIPTION
Changes:
Add UsesOptionsLinks as a prop to gw-header

Why:
For some use cases, I don't really need all the dropdown links because the user might not be allowed to see some settings. Here we provide a way to control the links from outside but we let the actual behavior as default.

How:
We define the options we support as an array of strings in order to let the user(Developer) give us which options he wants to render 

```
[      
 "settingsUsersProfile",
 "settingsCompaniesProfile",
 "settingsAppsCustomFieldsList",
 "settingsManagerList"
]
```
